### PR TITLE
do not attempt to delete modified buffers

### DIFF
--- a/plugin/wipeout.vim
+++ b/plugin/wipeout.vim
@@ -22,7 +22,7 @@ function! Wipeout(bang)
     let l:cmd .= '!'
   endif
   for b in range(1, bufnr('$'))
-    if buflisted(b) && !has_key(visible, b)
+    if !getbufvar(buflisted(b), "&mod") && !has_key(visible, b)
       let l:tally += 1
       exe l:cmd . ' ' . b
     endif

--- a/plugin/wipeout.vim
+++ b/plugin/wipeout.vim
@@ -17,15 +17,24 @@ function! Wipeout(bang)
   endfor
   " close any buffer that are loaded and not visible
   let l:tally = 0
+  let l:skips = 0
   let l:cmd = 'bw'
   if a:bang
     let l:cmd .= '!'
   endif
   for b in range(1, bufnr('$'))
-    if buflisted(b) && !getbufvar(b, "&mod") && !has_key(visible, b)
+    if buflisted(b) && !has_key(visible, b)
+      if getbufvar(b, "&mod")
+        let l:skips += 1
+        continue
+      endif
       let l:tally += 1
       exe l:cmd . ' ' . b
     endif
   endfor
-  echon "Deleted " . l:tally . " buffer" . (l:tally == 1 ? "" : "s")
+  let l:msg = "Deleted " . l:tally . " buffer" . (l:tally == 1 ? "" : "s")
+  if l:skips
+    let l:msg .= ", skipped " . l:skips . " modified buffer" . (l:skips == 1 ? "" : "s")
+  endif
+  echon l:msg
 endfun

--- a/plugin/wipeout.vim
+++ b/plugin/wipeout.vim
@@ -22,7 +22,7 @@ function! Wipeout(bang)
     let l:cmd .= '!'
   endif
   for b in range(1, bufnr('$'))
-    if !getbufvar(buflisted(b), "&mod") && !has_key(visible, b)
+    if buflisted(b) && !getbufvar(b, "&mod") && !has_key(visible, b)
       let l:tally += 1
       exe l:cmd . ' ' . b
     endif


### PR DESCRIPTION
If plugin tries to delete a buffer is modified, error shows and that doesn't look up, so skip should be right thing to do since the buffer isn't saved.
