### PR TITLE
Wipeout unlisted buffers when used with a bang

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ Usage
 ```
 :Wipeout
 ```
+
+Alternatively, to wipe all buffers, including unlisted ones, use:
+
+```
+:WipeoutAll
+```

--- a/plugin/wipeout.vim
+++ b/plugin/wipeout.vim
@@ -24,7 +24,7 @@ function! Wipeout(bang, wipeUnlisted)
     let l:cmd .= '!'
   endif
   for b in range(1, bufnr('$'))
-    if (a:wipeUnlisted || buflisted(b)) && !has_key(visible, b)
+    if ((a:wipeUnlisted && bufexists(b)) || buflisted(b)) && !has_key(visible, b)
       if getbufvar(b, "&mod")
         let l:skips += 1
         continue

--- a/plugin/wipeout.vim
+++ b/plugin/wipeout.vim
@@ -5,9 +5,10 @@
 "
 " Author: Artem Nezvigin <artem@artnez.com>
 
-command! -bang Wipeout :call Wipeout(<bang>0)
+command! -bang Wipeout :call Wipeout(<bang>0, 0)
+command! -bang WipeoutAll :call Wipeout(<bang>0, 1)
 
-function! Wipeout(bang)
+function! Wipeout(bang, wipeUnlisted)
   " figure out which buffers are visible in any tab
   let visible = {}
   for t in range(1, tabpagenr('$'))
@@ -23,7 +24,7 @@ function! Wipeout(bang)
     let l:cmd .= '!'
   endif
   for b in range(1, bufnr('$'))
-    if buflisted(b) && !has_key(visible, b)
+    if (a:wipeUnlisted || buflisted(b)) && !has_key(visible, b)
       if getbufvar(b, "&mod")
         let l:skips += 1
         continue


### PR DESCRIPTION
~~When calling the function with a bang (`:Wipeout!`), also delete unlisted buffers. This follows the behavior or `:ls!`.~~ See below.
